### PR TITLE
platos flood adds voxels by flooding to highest value neighbors

### DIFF
--- a/platos_flood.py
+++ b/platos_flood.py
@@ -1,0 +1,64 @@
+import load_json
+import numpy as np
+from math import floor
+
+# generate 3d matrix with sum of chair voxels in each cell
+def generate_average_voxel_matrix (resolution):
+
+    # load models
+    models = load_json.load_folder('models', resolution)
+
+    # empty 3d matrix of ints to hold value sums
+    voxel_matrix = np.zeros((resolution, resolution, resolution), np.int8)
+
+    # sum chair voxels into matrix
+    voxel_count = 0
+    for chair in models:
+        for vox in chair:
+            voxel_matrix[vox[0], vox[1], vox[2]] += 1
+            voxel_count += 1
+
+    return voxel_matrix, floor(voxel_count / len(models))
+
+def platos_flood (resolution):
+
+    # get matrix with # of chair voxels at each cell & average vox per chair
+    voxel_matrix, avg_vox = generate_average_voxel_matrix(resolution)
+
+    print("average voxels per chair: ", avg_vox)
+
+    # start with first highest value voxel
+    max_vox = np.unravel_index(voxel_matrix.argmax(), voxel_matrix.shape)
+
+    # store voxels as tuple with value first -> (value, x, y, z)
+    seed = (voxel_matrix[max_vox], max_vox[0], max_vox[1], max_vox[2])
+
+    print("seed: ", seed)
+
+    # start neighbors set with seed and add highest neighbor to platos chair
+    # until average # of voxels per chair reached
+    neighbors = set([seed])
+    platos = set()
+    while len(platos) < avg_vox:
+
+        # find next voxel with highest value from neighbors & add to platos
+        next_vox = sorted(neighbors).pop()
+        neighbors.remove(next_vox)
+        platos.add(next_vox)
+
+        # add next voxels neighbors to neighbors
+        for x, y, z in [(-1,0,0),(0,-1,0),(0,0,-1),(1,0,0),(0,1,0),(0,0,1)]:
+            coords = (x + next_vox[1], y + next_vox[2], z + next_vox[3])
+            if min(coords) > -1 and max(coords) < resolution:
+                value = voxel_matrix[coords]
+                neighbor_vox = (value, coords[0], coords[1], coords[2])
+                if neighbor_vox not in platos:
+                    neighbors.add(neighbor_vox)
+
+        print("*", next_vox)
+
+    # strip out values and just return [x, y, z] coords lists
+    return [list(coords[1:]) for coords in platos]
+
+if __name__ == "__main__":
+    platos_chair = platos_flood(60)

--- a/supernormal.py
+++ b/supernormal.py
@@ -7,6 +7,7 @@ import OpenGL.GLU as glu
 import average_chair
 import math 
 import numpy as np 
+from platos_flood import platos_flood
 
 
 import pprint
@@ -73,7 +74,8 @@ def main():
 
     # cubes = average_chair.single_cell(RESOLUTION,THRESHOLD) 
     # cubes = average_chair.neighbors (RESOLUTION,THRESHOLD) 
-    cubes = average_chair.flood(RESOLUTION,THRESHOLD) 
+    #cubes = average_chair.flood(RESOLUTION,THRESHOLD) 
+    cubes = platos_flood(RESOLUTION)
 
     # exportForMatlab(cubes)
 


### PR DESCRIPTION
try it is workingish!

![platos_chair_0](https://user-images.githubusercontent.com/5488759/41962130-193f1ef4-79a9-11e8-85a8-58c0a33ade7a.png)
![platos_chair_1](https://user-images.githubusercontent.com/5488759/41962134-1db98e38-79a9-11e8-8a0f-84ffd7c2aee6.png)

to prevent getting stuck you have to check that you dont add voxels already in platos chair back to neighbor set (check in platos flood on line 55)

is lopsided now because sorts by # of chairs in cell value & then by x, y, z value, so positive x, y, z quadrant is added to first -- amongst neighboring voxels with highest value, it looks like there are often many neighbors with the max value, and then chair grows in positive direction

could be fixed by sorting by distance from center of matrix to grow in a more balanced way?

could track voxels like so -> (value, distance, x, y, z) then sort tiebreaker would be distance before x value